### PR TITLE
Add docs and gitpod file for dev setup

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,67 @@
+# Gitpod docker image for WordPress | https://github.com/luizbills/gitpod-wordpress
+# License: MIT (c) 2020 Luiz Paulo "Bills"
+# Version: 0.8
+FROM gitpod/workspace-mysql
+
+### General Settings ###
+ENV PHP_VERSION="7.4"
+ENV APACHE_DOCROOT="public_html"
+
+### Setups, Node, NPM ###
+USER gitpod
+ADD https://api.wordpress.org/secret-key/1.1/salt?rnd=152634 /dev/null
+RUN git clone https://github.com/luizbills/gitpod-wordpress $HOME/gitpod-wordpress && \
+    cat $HOME/gitpod-wordpress/conf/.bashrc.sh >> $HOME/.bashrc && \
+    . $HOME/.bashrc && \
+    bash -c ". .nvm/nvm.sh && nvm install --lts"
+
+### MailHog ###
+USER root
+ARG DEBIAN_FRONTEND=noninteractive
+RUN go get github.com/mailhog/MailHog && \
+    go get github.com/mailhog/mhsendmail && \
+    cp $GOPATH/bin/MailHog /usr/local/bin/mailhog && \
+    cp $GOPATH/bin/mhsendmail /usr/local/bin/mhsendmail && \
+    ln $GOPATH/bin/mhsendmail /usr/sbin/sendmail && \
+    ln $GOPATH/bin/mhsendmail /usr/bin/mail &&\
+    ### Apache ###
+    apt-get -y install apache2 && \
+    chown -R gitpod:gitpod /var/run/apache2 /var/lock/apache2 /var/log/apache2 && \
+    echo "include $HOME/gitpod-wordpress/conf/apache.conf" > /etc/apache2/apache2.conf && \
+    echo ". $HOME/gitpod-wordpress/conf/apache.env.sh" > /etc/apache2/envvars && \
+    ### PHP ###
+    apt-get -qy purge php* && \
+    add-apt-repository ppa:ondrej/php && \
+    apt-get update && \
+    apt-get -qy install \
+        libapache2-mod-php \
+        php${PHP_VERSION} \
+        php${PHP_VERSION}-common \
+        php${PHP_VERSION}-cli \
+        php${PHP_VERSION}-mbstring \
+        php${PHP_VERSION}-curl \
+        php${PHP_VERSION}-gd \
+        php${PHP_VERSION}-intl \
+        php${PHP_VERSION}-mysql \
+        php${PHP_VERSION}-xml \
+        php${PHP_VERSION}-json \
+        php${PHP_VERSION}-zip \
+        php${PHP_VERSION}-soap \
+        php${PHP_VERSION}-bcmath \
+        php${PHP_VERSION}-opcache \
+        php-xdebug && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* && \
+    update-alternatives --set php /usr/bin/php${PHP_VERSION} && \
+    cat /home/gitpod/gitpod-wordpress/conf/php.ini >> /etc/php/${PHP_VERSION}/apache2/php.ini && \
+    ### Setup PHP in Apache ###
+    a2dismod php* && \
+    a2dismod mpm_* && \
+    a2enmod mpm_prefork && \
+    a2enmod php${PHP_VERSION} && \
+    ### WP-CLI ###
+    wget -q https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O $HOME/wp-cli.phar && \
+    chmod +x $HOME/wp-cli.phar && \
+    mv $HOME/wp-cli.phar /usr/local/bin/wp && \
+    chown gitpod:gitpod /usr/local/bin/wp
+
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: echo 'init script' # runs during prebuild
+    command: echo 'start script'
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 8000
+    onOpen: open-preview

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,47 @@
+# Getting started with 
+
+
+## Setting up with a local environment
+
+Using MAMP, or localwp, or your preferred tool, download the this repo a wordpress install. Develop as usual.
+
+## Setting up with gitpod
+
+If you have an account with hosted gitpod service, or self-hosted version, you set up an development environment in browser.
+
+The notes below outline the steps taken before your workspace is ready.
+
+
+## What the dockerfile does:
+
+### Clone the gitpod wordpress repo
+
+this also copies the `.bashrc` which contains a few bash handy functions: `wp-setup`, `wp-setup-plugin`, `wp-setup-theme`, and `browse-url`. We'll cover them in more detail below.
+
+### Install a LTS node
+
+### Install mailhog for previewing and checking emails
+
+### Install Apache Webserver
+
+### Installs PHP
+
+It currently install php version 7.4.
+
+### Set up PHP to work with Apache
+
+### Install WP-CLI
+
+## What the "wp-setup" functions do when you start the dev environment
+
+You call `wp-setup-plugin`, or `wp-setup-theme`, the `wp-setup` does the following things:
+
+1. creates the mysql user and database
+1. downloads wordpress
+1. performs a `wp-core` install with wp-cli
+1. moves the gitpod workspace into the correct place in `wp-content`, so your workspace is in either the `plugins`, or the `themes` directory
+1. install any npm dependencies for front end work
+1. install any php dependencies defined in composer
+1. execute an `.init.sh` file if it exists, to do any other arbitrary tasks.
+
+


### PR DESCRIPTION
This PR adds a gitpod file, as an experiment in setting up a remote development environment for wordpress.

Ideally, this would mean we can spin up ephemeral workspaces for each issue or new feature, and avoid the pain and inconsistencies associated with setting up a local environments each time we want to make changes.