### PR TITLE
Remove the unnecessary badge ?nocache param

### DIFF
--- a/templates/checker/checker-result-green.php
+++ b/templates/checker/checker-result-green.php
@@ -66,12 +66,12 @@
 			<div class="wp-block-columns">
 				<div class="wp-block-column">
 					<h3>Image</h3>
-					<img src="https://api.thegreenwebfoundation.org/greencheckimage/<?php echo esc_html( $green_check_result->url ); ?>?nocache=true" alt="This website is hosted Green - checked by thegreenwebfoundation.org">
+					<img src="https://api.thegreenwebfoundation.org/greencheckimage/<?php echo esc_html( $green_check_result->url ); ?>" alt="This website is hosted Green - checked by thegreenwebfoundation.org">
 				</div>
 
 				<div class="wp-block-column">
 					<h3>Code</h3>
-					<pre><code><?php echo htmlspecialchars( '<img src="https://api.thegreenwebfoundation.org/greencheckimage/') . esc_html( $green_check_result->url ) . '?nocache=true' . htmlspecialchars( '" alt="This website is hosted Green - checked by thegreenwebfoundation.org">' ); ?></code></pre>
+					<pre><code><?php echo htmlspecialchars( '<img src="https://api.thegreenwebfoundation.org/greencheckimage/') . esc_html( $green_check_result->url ) . htmlspecialchars( '" alt="This website is hosted Green - checked by thegreenwebfoundation.org">' ); ?></code></pre>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This PR removes the `?nocache=true` snippet from the code snippet we share with people to put on their own site.

This is partly a response to this issue coming up today - as when you serving an image from a url, that someone would make a GET request to, it's sort of rare to send GET params along too.

If there are GET params in the url tha returns an image, it might resemble an attack where people try to use GET params to share someone's cookies to another domain.

Under the hood, we have updated our approach to caching, so we have less of a need for the `?nocache` param anyway, and removing it lets us eliminate one factor from this Avast problem we're experiencing today.

https://github.com/thegreenwebfoundation/admin-portal/issues/470