### PR TITLE
WIP: Hs refresh check result

### DIFF
--- a/src/green-web-checker.php
+++ b/src/green-web-checker.php
@@ -21,7 +21,7 @@ function tgwf_run_site_check() {
 	$cacheflag = '';
 
 	if ( isset( $_GET['nocache'] ) && ! empty( $_GET['nocache'] ) ) {
-		$cacheflag = '?' . $_GET['nocache'];
+		$cacheflag = '?nocache=' . $_GET['nocache'];
 	}
 
 	// Request and decode the response.

--- a/src/green-web-checker.php
+++ b/src/green-web-checker.php
@@ -17,21 +17,28 @@ function tgwf_run_site_check() {
 	$greencheck = str_replace( 'https://', '', $greencheck );
 	$greencheck = explode( '/', $greencheck );
 
+	// Work out if the nocache flag is set or not, and prep it.
+	$cacheflag = '';
+
+	if ( isset( $_GET['nocache'] ) && ! empty( $_GET['nocache'] ) ) {
+		$cacheflag = '?' . $_GET['nocache'];
+	}
+
 	// Request and decode the response.
-	$response           = wp_remote_get( 'https://api.thegreenwebfoundation.org/greencheck/' . $greencheck[0] . '?nocache=true', [ 'timeout' => 10 ] );
+	$response = wp_remote_get( 'https://api.thegreenwebfoundation.org/greencheck/' . $greencheck[0] . $cacheflag, [ 'timeout' => 10 ] );
 	$green_check_result = json_decode( wp_remote_retrieve_body( $response ) );
 
 	return $green_check_result;
 }
 
 /**
- * Perform a hosting companu check.
+ * Perform a hosting company check.
  */
 function tgwf_run_hosting_company_check( $host_id ) {
 	$hosting_company_result = '';
 
 	// Request and decode the response.
-	$response               = wp_remote_get( 'https://api.thegreenwebfoundation.org/data/hostingprovider/' . $host_id . '?nocache=true', [ 'timeout' => 10 ] );
+	$response               = wp_remote_get( 'https://api.thegreenwebfoundation.org/data/hostingprovider/' . $host_id, [ 'timeout' => 10 ] );
 	$hosting_company_result = json_decode( wp_remote_retrieve_body( $response ) );
 
 	return $hosting_company_result;

--- a/templates/checker/checker-result-green.php
+++ b/templates/checker/checker-result-green.php
@@ -39,10 +39,12 @@
 
 				<?php
 				if ( isset( $green_check_result->hosted_by ) ) :
+					$modified_date = date('d M Y', strtotime( $green_check_result->modified ) );
+					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
 					?>
 
 					<p style="margin-top: 2rem; font-weight: bold;">Hosted by: <a href="https://app.greenweb.org/directory/#<?php echo esc_html( $green_check_result->hosted_by_id ); ?>"><?php echo esc_html( $green_check_result->hosted_by ); ?></a></p>																					
-
+					
 					<?php
 					if ( isset( $green_check_result->supporting_documents ) ) :
 						$docs = $green_check_result->supporting_documents;
@@ -69,6 +71,9 @@
 						endif;
 					endif;
 					?>
+
+					<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?>. <a href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>
+
 					<?php
 				endif;
 				?>	

--- a/templates/checker/checker-result-green.php
+++ b/templates/checker/checker-result-green.php
@@ -72,7 +72,7 @@
 					endif;
 					?>
 
-					<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?>. <a href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>
+					<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?> UTC. <a href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>
 
 					<?php
 				endif;

--- a/templates/checker/checker-result-green.php
+++ b/templates/checker/checker-result-green.php
@@ -39,8 +39,8 @@
 
 				<?php
 				if ( isset( $green_check_result->hosted_by ) ) :
-					$modified_date = date('d M Y h:m', strtotime( $green_check_result->modified ) );
-					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
+					$modified_date = date('d M Y h:i', strtotime( $green_check_result->modified ) );
+					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "&nocache=true";
 					?>
 
 					<p style="margin-top: 2rem; font-weight: bold;">Hosted by: <a href="https://app.greenweb.org/directory/#<?php echo esc_html( $green_check_result->hosted_by_id ); ?>"><?php echo esc_html( $green_check_result->hosted_by ); ?></a></p>																					

--- a/templates/checker/checker-result-green.php
+++ b/templates/checker/checker-result-green.php
@@ -39,7 +39,7 @@
 
 				<?php
 				if ( isset( $green_check_result->hosted_by ) ) :
-					$modified_date = date('d M Y', strtotime( $green_check_result->modified ) );
+					$modified_date = date('d M Y h:m', strtotime( $green_check_result->modified ) );
 					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
 					?>
 

--- a/templates/checker/checker-result-not-green.php
+++ b/templates/checker/checker-result-not-green.php
@@ -35,6 +35,13 @@
 				<p>For a check to return a green result, we need evidence to demonstrate what steps are being taken to avoid, reduce or offset the emissions caused by the digital infrastructure used.</p>
 				<p><a style="color: white;" href="https://www.thegreenwebfoundation.org/support/why-does-my-website-show-up-as-grey-in-the-green-web-checker/">Why does my website show up as grey in the Green Web Checker?</a>
 			
+				<?php
+					$modified_date = date('d M Y', strtotime( $green_check_result->modified ) );
+					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
+				?>
+
+				<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?>. <a style="color: white;" href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>
+
 				<p class="mb-0" style="text-align: right;">Our take on <a style="color: white;" href="https://www.thegreenwebfoundation.org/support/why-does-green-hosting-matter/">why green hosting matters.</a></p>
 
 			</div>

--- a/templates/checker/checker-result-not-green.php
+++ b/templates/checker/checker-result-not-green.php
@@ -36,8 +36,8 @@
 				<p><a style="color: white;" href="https://www.thegreenwebfoundation.org/support/why-does-my-website-show-up-as-grey-in-the-green-web-checker/">Why does my website show up as grey in the Green Web Checker?</a>
 			
 				<?php
-					$modified_date = date('d M Y h:m', strtotime( $green_check_result->modified ) );
-					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
+					$modified_date = date('d M Y h:i', strtotime( $green_check_result->modified ) );
+					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "&nocache=true";
 				?>
 
 				<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?> UTC. <a style="color: white;" href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>

--- a/templates/checker/checker-result-not-green.php
+++ b/templates/checker/checker-result-not-green.php
@@ -36,7 +36,7 @@
 				<p><a style="color: white;" href="https://www.thegreenwebfoundation.org/support/why-does-my-website-show-up-as-grey-in-the-green-web-checker/">Why does my website show up as grey in the Green Web Checker?</a>
 			
 				<?php
-					$modified_date = date('d M Y', strtotime( $green_check_result->modified ) );
+					$modified_date = date('d M Y h:m', strtotime( $green_check_result->modified ) );
 					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
 				?>
 

--- a/templates/checker/checker-result-not-green.php
+++ b/templates/checker/checker-result-not-green.php
@@ -40,7 +40,7 @@
 					$retest_url = get_bloginfo( 'url' ) . "/green-web-check/?url=" . $green_check_result->url . "?nocache=true";
 				?>
 
-				<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?>. <a style="color: white;" href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>
+				<p style="margin-top: 2rem; font-size: 0.85em;">This url was last tested on <?php echo esc_html( $modified_date ); ?> UTC. <a style="color: white;" href="<?php echo esc_url( $retest_url ); ?>">Refresh check</a></p>
 
 				<p class="mb-0" style="text-align: right;">Our take on <a style="color: white;" href="https://www.thegreenwebfoundation.org/support/why-does-green-hosting-matter/">why green hosting matters.</a></p>
 


### PR DESCRIPTION
The problem is that the Green Web checker caches results, and now our linked domains implementation does not require providers to manually input their client domains, we’ve got no way of knowing for which domains we need to expire the existing incorrect results in the cache.

Our proposed solution is to add a link to the greenweb result to force a cache refresh, which can be used by anyone who spots an incorrect result. This way providers have a way to update their results after configuring carbon.txt, and can confirm the solution works.

https://trello.com/c/MK2FEBI5/613-add-a-refresh-link-to-the-green-web-check-results-page